### PR TITLE
Make VLC run in a permanet window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ mv $env:APPDATA\Dakara\player_vlc.yaml $env:APPDATA\Dakara\player.yaml
 - mpv is supported as an alternative player.
   In the config file, the player can be selected in the `player.player_name` key.
   Current accepted values are `vlc` and `mpv`.
+- VLC runs in a permanent Tkinter window if possible, which doesn't close between media.
+  The old behavior can be restored in config file using the `player.vlc.use_default_window` key.
 
 ### Changed
 

--- a/src/dakara_player/resources/player.yaml
+++ b/src/dakara_player/resources/player.yaml
@@ -57,6 +57,13 @@ player:
       # On Windows:
       # You should not have this problem.
 
+    # Make VLC manage its own window
+    # By default, a permanent Tkinter window is created and passed to VLC if
+    # possible. In contrast, when VLC manages its window, it will create a new
+    # one for each media, which may result in a blinking effect (especially
+    # visible on Windows).
+    # use_default_window = False
+
   # Parameters for mpv
   # You can define specific options for mpv from here
   # To get a complete list of the available options, consult mpv documentation:

--- a/src/dakara_player/window.py
+++ b/src/dakara_player/window.py
@@ -12,106 +12,225 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def get_window_manager_class():
-    if TkWindowManager.is_available():
-        return TkWindowManager
-
-    return DummyWindowManger
-
-
 class BaseWindowManager(ABC):
+    """Abstract class for window manager
+
+    Args:
+        title (str): Title of the window.
+        fullscreen (bool): If true, the window is fullscreen.
+        disabled (bool): If True, no window are displayed.
+    """
+
     GREETINGS = "Abstract window manager selected"
 
     @staticmethod
     @abstractmethod
     def is_available():
-        pass
+        """Tell if this window manager can be initialized
 
-    def __init__(self, stop, errors, title="No title", fullscreen=False):
+        Returns:
+            bool: True if the window managen can be initialized.
+        """
+
+    def __init__(self, title="No title", fullscreen=False, disabled=False):
         if not self.is_available():
-            raise Exception("not available")
+            raise WindowManagerNotAvailableError(
+                "This window manager cannot be initialized"
+            )
 
         logger.debug(self.GREETINGS)
+        self.title = title
+        self.fullscreen = fullscreen
+        self.disabled = disabled
 
-        self.stop = stop
-        self.errors = errors
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
 
     @abstractmethod
     def open(self):
-        pass
+        """Open the window
+        """
 
     @abstractmethod
     def close(self):
-        pass
+        """Close the window
+        """
 
     @abstractmethod
     def get_id(self):
-        pass
+        """Get window ID
+
+        Retuns:
+            int: ID of the window.
+        """
 
 
-class DummyWindowManger(BaseWindowManager):
+class DummyWindowManager(BaseWindowManager):
+    """Dummy window manager
+
+    It never creates a window and is always available.
+
+    Args:
+        title (str): Title of the window.
+        fullscreen (bool): If true, the window is fullscreen.
+        disabled (bool): If True, no window are displayed.
+    """
+
     GREETINGS = "Dummy window manager selected"
 
     @staticmethod
     def is_available():
+        """Tell if this window manager can be initialized
+
+        Returns:
+            bool: True if the window managen can be initialized.
+        """
         return True
 
     def open(self):
-        pass
+        """Open the window
+        """
 
     def close(self):
-        pass
+        """Close the window
+        """
 
     def get_id(self):
+        """Get window ID
+
+        Retuns:
+            int: ID of the window.
+        """
         return None
 
 
 class TkWindowManager(BaseWindowManager):
+    """Tkinter window manager
+
+    Uses the Python default GUI library Tkinter.
+
+    The window is created in a separate thread and checks every
+    `ACTUALIZE_INTERVAL` if it has to close (using an event set by the `close`
+    method). This indirect approach works well, even if the window doesn't
+    close immediately at shutdown. A more direct approach was attempted using
+    `generate_event`, but this messes up the destruction order and leads to a
+    crash of the interpreter. Using `quit` instead of `destroy` as a workaround
+    was problematic for tests, as the method doesn't cleanup after itself,
+    making inpossible to close a second window.
+
+    See: https://stackoverflow.com/q/66529633/4584444
+
+    Args:
+        title (str): Title of the window.
+        fullscreen (bool): If true, the window is fullscreen.
+        disabled (bool): If True, no window are displayed.
+    """
+
     GREETINGS = "Tk window selected"
-    STOP_PROGRAM_EVENT = "<<stop_program>>"
-
-    class TkWindow:
-        def __init__(self, title, fullscreen):
-            self.root = tkinter.Tk()
-            self.root.title(title)
-            self.root.configure(width=800, height=600, bg="black", cursor="none")
-            self.root.resizable(True, True)
-            self.root.attributes("-fullscreen", fullscreen)
-            self.root.bind(TkWindowManager.STOP_PROGRAM_EVENT, self.close)
-            self.id = self.root.winfo_id()
-
-        def close(self, event):
-            self.root.destroy()
+    ACTUALIZE_INTERVAL = 1000
 
     @staticmethod
     def is_available():
+        """Tell if this window manager can be initialized
+
+        Returns:
+            bool: True if the window managen can be initialized.
+        """
         return tkinter is not None
 
-    def __init__(self, *args, title="No title", fullscreen=False, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.title = title
-        self.fullscreen = fullscreen
-        self.window = None
         self.window_thread = Thread(target=self.create_window)
+        self.stop = Event()
         self.ready = Event()
+        self.id = None
 
     def create_window(self):
+        """Create the window
+
+        Must be called in its own thread.
+        """
+
+        class TkWindow(tkinter.Tk):
+            """Custom Tk window
+            """
+
+            def __init__(self, stop, title, fullscreen, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.stop = stop
+                self.title(title)
+                self.configure(width=1024, height=576, bg="black", cursor="none")
+                self.resizable(True, True)
+                self.attributes("-fullscreen", fullscreen)
+                self.after(TkWindowManager.ACTUALIZE_INTERVAL, self.actualize)
+
+            def actualize(self):
+                """Check if the window has to be closed periodically
+                """
+                if self.stop.is_set():
+                    self.destroy()
+                    return
+
+                self.after(TkWindowManager.ACTUALIZE_INTERVAL, self.actualize)
+
         logger.debug("Creating Tk window thread")
-        self.window = self.TkWindow(self.title, self.fullscreen)
+        window = TkWindow(self.stop, self.title, self.fullscreen)
+        self.id = window.winfo_id()
+
+        # allow to not draw the window for testing purposes
+        if self.disabled:
+            window.withdraw()
+
         self.ready.set()
-        self.window.root.mainloop()
+        window.mainloop()
 
     def open(self):
+        """Open the window
+        """
         logger.debug("Creating Tk window")
         self.window_thread.start()
 
     def close(self):
+        """Close the window
+        """
         self.ready.wait()
         logger.debug("Closing Tk window")
-        self.window.root.event_generate(self.STOP_PROGRAM_EVENT)
+        self.stop.set()
         self.window_thread.join()
 
     def get_id(self):
+        """Get window ID
+
+        Retuns:
+            int: ID of the window.
+        """
         self.ready.wait()
         logger.debug("Getting Tk window ID")
-        return self.window.id
+        return self.id
+
+
+def get_window_manager_class():
+    """Give an available window manager class
+
+    Returns:
+        BaseWindowManager: Tries to return `TkWindowManager`, fallbacks to
+        `DummyWindowManager`.
+    """
+    if TkWindowManager.is_available():
+        return TkWindowManager
+
+    return DummyWindowManager
+
+
+WindowManager = get_window_manager_class()
+"""BaseWindowManager: Available window manager class
+"""
+
+
+class WindowManagerNotAvailableError(Exception):
+    """Error when initializing an unavailable window manager
+    """

--- a/src/dakara_player/window.py
+++ b/src/dakara_player/window.py
@@ -1,0 +1,117 @@
+import logging
+from abc import ABC, abstractmethod
+from threading import Thread, Event
+
+try:
+    import tkinter
+
+except ImportError:
+    tkinter = None
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_window_manager_class():
+    if TkWindowManager.is_available():
+        return TkWindowManager
+
+    return DummyWindowManger
+
+
+class BaseWindowManager(ABC):
+    GREETINGS = "Abstract window manager selected"
+
+    @staticmethod
+    @abstractmethod
+    def is_available():
+        pass
+
+    def __init__(self, stop, errors, title="No title", fullscreen=False):
+        if not self.is_available():
+            raise Exception("not available")
+
+        logger.debug(self.GREETINGS)
+
+        self.stop = stop
+        self.errors = errors
+
+    @abstractmethod
+    def open(self):
+        pass
+
+    @abstractmethod
+    def close(self):
+        pass
+
+    @abstractmethod
+    def get_id(self):
+        pass
+
+
+class DummyWindowManger(BaseWindowManager):
+    GREETINGS = "Dummy window manager selected"
+
+    @staticmethod
+    def is_available():
+        return True
+
+    def open(self):
+        pass
+
+    def close(self):
+        pass
+
+    def get_id(self):
+        return None
+
+
+class TkWindowManager(BaseWindowManager):
+    GREETINGS = "Tk window selected"
+    STOP_PROGRAM_EVENT = "<<stop_program>>"
+
+    class TkWindow:
+        def __init__(self, title, fullscreen):
+            self.root = tkinter.Tk()
+            self.root.title(title)
+            self.root.configure(width=800, height=600, bg="black", cursor="none")
+            self.root.resizable(True, True)
+            self.root.attributes("-fullscreen", fullscreen)
+            self.root.bind(TkWindowManager.STOP_PROGRAM_EVENT, self.close)
+            self.id = self.root.winfo_id()
+
+        def close(self, event):
+            self.root.destroy()
+
+    @staticmethod
+    def is_available():
+        return tkinter is not None
+
+    def __init__(self, *args, title="No title", fullscreen=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.title = title
+        self.fullscreen = fullscreen
+        self.window = None
+        self.window_thread = Thread(target=self.create_window)
+        self.ready = Event()
+
+    def create_window(self):
+        logger.debug("Creating Tk window thread")
+        self.window = self.TkWindow(self.title, self.fullscreen)
+        self.ready.set()
+        self.window.root.mainloop()
+
+    def open(self):
+        logger.debug("Creating Tk window")
+        self.window_thread.start()
+
+    def close(self):
+        self.ready.wait()
+        logger.debug("Closing Tk window")
+        self.window.root.event_generate(self.STOP_PROGRAM_EVENT)
+        self.window_thread.join()
+
+    def get_id(self):
+        self.ready.wait()
+        logger.debug("Getting Tk window ID")
+        return self.window.id

--- a/tests/integration/test_media_player_vlc.py
+++ b/tests/integration/test_media_player_vlc.py
@@ -34,6 +34,9 @@ class MediaPlayerVlcIntegrationTestCase(TestCasePoller):
             "--text-renderer=tdummy",
         ]
 
+        # use default window
+        self.use_default_window = True
+
         # create fullscreen flag
         self.fullscreen = True
 
@@ -98,6 +101,7 @@ class MediaPlayerVlcIntegrationTestCase(TestCasePoller):
                 "vlc": {
                     "instance_parameters": self.instance_parameters,
                     "media_parameters": self.media_parameters,
+                    "use_default_window": self.use_default_window,
                 },
             }
 

--- a/tests/unit/test_window.py
+++ b/tests/unit/test_window.py
@@ -1,5 +1,7 @@
+import sys
+import os
 from importlib import reload
-from unittest import TestCase, skipUnless
+from unittest import TestCase, skipIf, skipUnless
 from unittest.mock import patch
 
 try:
@@ -60,6 +62,10 @@ class TkWindowManagerTestCase(TestCase):
         with TkWindowManager(disabled=True):
             pass
 
+    @skipIf(
+        "linux" in sys.platform and "DISPLAY" not in os.environ,
+        "No display detected on Linux",
+    )
     def test_get_id(self):
         """Test to get Tk window ID
         """

--- a/tests/unit/test_window.py
+++ b/tests/unit/test_window.py
@@ -1,0 +1,68 @@
+from importlib import reload
+from unittest import TestCase, skipUnless
+from unittest.mock import patch
+
+try:
+    import tkinter
+
+except ImportError:
+    tkinter = None
+
+from dakara_player.window import (
+    DummyWindowManager,
+    TkWindowManager,
+    WindowManagerNotAvailableError,
+)
+
+
+class DummyWindowManagerTestCase(TestCase):
+    """Test the dummy window manager
+    """
+
+    @patch.object(DummyWindowManager, "is_available", return_value=False)
+    def test_init_not_available(self, mocked_is_available):
+        """Test to init an unavailable window manager
+        """
+        with self.assertRaises(WindowManagerNotAvailableError):
+            DummyWindowManager(None, None)
+
+        mocked_is_available.assert_called_with()
+
+    def test_open_close(self):
+        """Test to open and close dummy window
+        """
+        with DummyWindowManager():
+            pass
+
+    def test_get_id(self):
+        """Test to get dummy window ID
+        """
+        with DummyWindowManager() as window_manager:
+            self.assertIsNone(window_manager.get_id())
+
+
+@skipUnless(TkWindowManager.is_available(), "Tkinter not available")
+@patch.object(TkWindowManager, "ACTUALIZE_INTERVAL", 100)
+class TkWindowManagerTestCase(TestCase):
+    """Test the Tkinter window manager
+    """
+
+    @patch("dakara_player.window.tkinter", None)
+    def test_is_available_no_tkinter(self):
+        """Test to check availability of Tkinter window manager without Tkinter
+        """
+        self.assertFalse(TkWindowManager.is_available())
+
+    def test_open_close(self):
+        """Test to open and close Tk window
+        """
+        reload(tkinter)
+        with TkWindowManager(disabled=True):
+            pass
+
+    def test_get_id(self):
+        """Test to get Tk window ID
+        """
+        reload(tkinter)
+        with TkWindowManager(disabled=True) as window_manager:
+            self.assertIsNotNone(window_manager.get_id())

--- a/tests/unit/test_window.py
+++ b/tests/unit/test_window.py
@@ -1,6 +1,5 @@
 import sys
 import os
-from importlib import reload
 from unittest import TestCase, skipIf, skipUnless
 from unittest.mock import patch
 
@@ -55,10 +54,13 @@ class TkWindowManagerTestCase(TestCase):
         """
         self.assertFalse(TkWindowManager.is_available())
 
+    @skipIf(
+        "linux" in sys.platform and "DISPLAY" not in os.environ,
+        "No display detected on Linux",
+    )
     def test_open_close(self):
         """Test to open and close Tk window
         """
-        reload(tkinter)
         with TkWindowManager(disabled=True):
             pass
 
@@ -69,6 +71,5 @@ class TkWindowManagerTestCase(TestCase):
     def test_get_id(self):
         """Test to get Tk window ID
         """
-        reload(tkinter)
         with TkWindowManager(disabled=True) as window_manager:
             self.assertIsNotNone(window_manager.get_id())

--- a/tests/unit/test_window.py
+++ b/tests/unit/test_window.py
@@ -11,6 +11,7 @@ except ImportError:
 
 from dakara_player.window import (
     DummyWindowManager,
+    get_window_manager_class,
     TkWindowManager,
     WindowManagerNotAvailableError,
 )
@@ -73,3 +74,20 @@ class TkWindowManagerTestCase(TestCase):
         """
         with TkWindowManager(disabled=True) as window_manager:
             self.assertIsNotNone(window_manager.get_id())
+
+
+class GetWindowManagerClassTestCase(TestCase):
+    """Test the get_window_manager_class helper
+    """
+
+    @patch.object(TkWindowManager, "is_available", return_value=True)
+    def test_get_tk_window_manager(self, mocked_is_available):
+        """Test to get the Tkinter window manager
+        """
+        self.assertIs(get_window_manager_class(), TkWindowManager)
+
+    @patch.object(TkWindowManager, "is_available", return_value=False)
+    def test_get_dummy_window_manager(self, mocked_is_available):
+        """Test to get the Tkinter window manager
+        """
+        self.assertIs(get_window_manager_class(), DummyWindowManager)


### PR DESCRIPTION
Fixes #6, fixes #15.

When VLC manages its own window, it will create a new one for every media. On Linux, the window stays more or less open, so this is not that much noticeable, but on Windows, the window manager animation makes it impossible to miss, as reported in #15. More over, this approach suffers from bugs: some videos can break fullscreen mode (#6) or, on dual screen, the window can be opened on a different monitor (the one where the cursor is).

This MR aims to create a single, permanent window with Tkinter and to assign VLC to render in it using [`set_xwindow`](https://www.olivieraubert.net/vlc/python-ctypes/doc/vlc.MediaPlayer-class.html#set_xwindow) on Linux, and [`set_hwnd`](https://www.olivieraubert.net/vlc/python-ctypes/doc/vlc.MediaPlayer-class.html#set_hwnd) on Windows.