### PR TITLE
Fix VLC crash temporarily

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,7 +90,8 @@ for:
 
     install:
       # install system dependencies if requested
-      - "if %INTEGRATION_TEST% == true (cinst vlc --force --version=3.0.12 mpv)"
+      - "if %INTEGRATION_TEST% == true (cinst vlc --force --version=3.0.12)"
+      - "if %INTEGRATION_TEST% == true (cinst mpv)"
 
       # the features used in setup.cfg require a recent enough version of setuptools
       - "py -%PYTHON% -m pip install --upgrade \"setuptools>=40.0\""

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,7 +90,7 @@ for:
 
     install:
       # install system dependencies if requested
-      - "if %INTEGRATION_TEST% == true (cinst vlc mpv)"
+      - "if %INTEGRATION_TEST% == true (cinst vlc --force --version=3.0.12 mpv)"
 
       # the features used in setup.cfg require a recent enough version of setuptools
       - "py -%PYTHON% -m pip install --upgrade \"setuptools>=40.0\""

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installation guidelines are provided over here:
 
 At least one of there players:
 
-* [VLC](https://www.videolan.org/vlc/) (supported version: 3.0.0 and higher);
+* [VLC](https://www.videolan.org/vlc/) (supported version: 3.0.0 and higher, note that versions 3.0.13 and 3.0.14 cannot be used);
 * [mpv](https://mpv.io/) (supported version: 0.27 and higher).
 
 For 64 bits operating systems, you must install the equivalent version of the requirements.


### PR DESCRIPTION
VLC version 3.0.13 and 3.0.14 crashes with the Python-VLC wrapper, even for simple cases. Before having a permanent solution, this PR restrict installation of VLC to different versions.

See also https://github.com/oaubert/python-vlc/issues/178.