### PR TITLE
Blacklist VLC versions 3.0.13 and 3.0.14

### DIFF
--- a/src/dakara_player/media_player/vlc.py
+++ b/src/dakara_player/media_player/vlc.py
@@ -6,7 +6,7 @@ import sys
 from dakara_base.exceptions import DakaraError
 from dakara_base.safe_workers import safe
 from dakara_player.window import WindowManager, DummyWindowManager
-from packaging.version import parse
+from packaging.version import parse, Version
 
 try:
     import vlc
@@ -181,6 +181,11 @@ class MediaPlayerVlc(MediaPlayer):
 
         if version.major < 3:
             raise VlcTooOldError("VLC is too old (version 3 and higher supported)")
+
+        if version in (Version("3.0.13"), Version("3.0.14")):
+            logger.warning(
+                "This version of VLC is known to not work with Dakara player"
+            )
 
     def set_vlc_default_callbacks(self):
         """Set VLC default callbacks.

--- a/tests/unit/test_media_player_vlc.py
+++ b/tests/unit/test_media_player_vlc.py
@@ -263,6 +263,46 @@ class MediaPlayerVlcTestCase(TestCase):
             with self.assertRaisesRegex(VlcTooOldError, "VLC is too old"):
                 vlc_player.check_version()
 
+    @patch.object(MediaPlayerVlc, "get_version")
+    def test_check_version_3013(self, mocked_get_version):
+        """Test to check VLC version 3.0.13
+        """
+        with self.get_instance() as (vlc_player, _, _):
+            # mock the version of VLC
+            mocked_get_version.return_value = parse("3.0.13")
+
+            # call the method
+            with self.assertLogs("dakara_player.media_player.vlc", "WARNING") as logger:
+                vlc_player.check_version()
+
+            self.assertListEqual(
+                logger.output,
+                [
+                    "WARNING:dakara_player.media_player.vlc:This version of VLC "
+                    "is known to not work with Dakara player"
+                ],
+            )
+
+    @patch.object(MediaPlayerVlc, "get_version")
+    def test_check_version_3014(self, mocked_get_version):
+        """Test to check VLC version 3.0.14
+        """
+        with self.get_instance() as (vlc_player, _, _):
+            # mock the version of VLC
+            mocked_get_version.return_value = parse("3.0.14")
+
+            # call the method
+            with self.assertLogs("dakara_player.media_player.vlc", "WARNING") as logger:
+                vlc_player.check_version()
+
+            self.assertListEqual(
+                logger.output,
+                [
+                    "WARNING:dakara_player.media_player.vlc:This version of VLC "
+                    "is known to not work with Dakara player"
+                ],
+            )
+
     @patch.object(Path, "exists")
     def test_check_kara_folder_path(self, mocked_exists):
         """Test to check if the kara folder exists


### PR DESCRIPTION
This PR blacklists known incompatible versions of VLC with the player.