### PR TITLE
Skip any song before playing the idle screen

### DIFF
--- a/src/dakara_player/dakara_manager.py
+++ b/src/dakara_player/dakara_manager.py
@@ -121,6 +121,9 @@ class DakaraManager:
 
     def play_idle_screen(self):
         """Play the idle screen."""
+        # skip currently playing file if any
+        self.media_player.skip(no_callback=True)
+
         self.media_player.play("idle")
 
     def do_command(self, command):

--- a/src/dakara_player/media_player/base.py
+++ b/src/dakara_player/media_player/base.py
@@ -265,11 +265,15 @@ class MediaPlayer(Worker, ABC):
         """
 
     @abstractmethod
-    def skip(self):
+    def skip(self, no_callback=False):
         """Request to skip the current media.
 
         Can only work on transition screens or songs. The media player should
         continue playing, but media has to be considered already finished.
+
+        Args:
+            no_callback (bool): If True, no callback to signal the song has
+                finished will be executed.
 
         Must be overriden.
         """

--- a/src/dakara_player/media_player/mpv.py
+++ b/src/dakara_player/media_player/mpv.py
@@ -410,16 +410,22 @@ class MediaPlayerMpvOld(MediaPlayerMpv):
         logger.info("Resuming play")
         self.player.pause = False
 
-    def skip(self):
+    def skip(self, no_callback=False):
         """Request to skip the current media.
 
         Can only work on transition screens or songs. mpv should
         continue playing, but media has to be considered already finished.
+
+        Args:
+            no_callback (bool): If True, no callback to signal the song has
+                finished will be executed.
         """
         if self.is_playing_this("transition") or self.is_playing_this("song"):
             logger.info("Skipping '%s'", self.playlist_entry["song"]["title"])
             self.player_data["skip"] = True
-            self.callbacks["finished"](self.playlist_entry["id"])
+            if not no_callback:
+                self.callbacks["finished"](self.playlist_entry["id"])
+
             self.clear_playlist_entry()
 
     def stop_player(self):
@@ -773,7 +779,9 @@ class MediaPlayerMpvPost0330(MediaPlayerMpvOld):
         if what == "idle":
             return media_path == self.background_loader.backgrounds["idle"]
 
-        return media_path == self.playlist_entry_data[what].path
+        return (
+            media_path == self.playlist_entry_data[what].path and media_path is not None
+        )
 
     @safe
     def handle_end_file(self, event):

--- a/src/dakara_player/media_player/vlc.py
+++ b/src/dakara_player/media_player/vlc.py
@@ -247,7 +247,11 @@ class MediaPlayerVlc(MediaPlayer):
         Returns:
             bool: True if VLC is playing the requested type.
         """
-        return get_metadata(self.player.get_media())["type"] == what
+        media = self.player.get_media()
+        if not media:
+            return False
+
+        return get_metadata(media)["type"] == what
 
     def play(self, what):
         """Request VLC to play something.
@@ -321,15 +325,21 @@ class MediaPlayerVlc(MediaPlayer):
         logger.info("Resuming play")
         self.player.play()
 
-    def skip(self):
+    def skip(self, no_callback=False):
         """Request to skip the current media.
 
         Can only work on transition screens or songs. VLC should continue
         playing, but media has to be considered already finished.
+
+        Args:
+            no_callback (bool): If True, no callback to signal the song has
+                finished will be executed.
         """
         if self.is_playing_this("transition") or self.is_playing_this("song"):
-            self.callbacks["finished"](self.playlist_entry["id"])
             logger.info("Skipping '%s'", self.playlist_entry["song"]["title"])
+            if not no_callback:
+                self.callbacks["finished"](self.playlist_entry["id"])
+
             self.clear_playlist_entry()
 
     def stop_player(self):

--- a/tests/integration/test_media_player_vlc.py
+++ b/tests/integration/test_media_player_vlc.py
@@ -104,6 +104,15 @@ class MediaPlayerVlcIntegrationTestCase(TestCasePollerKara):
         self.assertNotEqual(METADATA_KEYS_COUNT, 0)
 
     @func_set_timeout(TIMEOUT)
+    def test_start(self):
+        """Test the initial state of the player without instructions."""
+        with self.get_instance() as (mpv_player, _, _):
+            self.assertIsNone(mpv_player.playlist_entry)
+            self.assertFalse(mpv_player.is_playing_this("idle"))
+            self.assertFalse(mpv_player.is_playing_this("transition"))
+            self.assertFalse(mpv_player.is_playing_this("song"))
+
+    @func_set_timeout(TIMEOUT)
     def test_play_idle(self):
         """Test to display the idle screen."""
         with self.get_instance() as (vlc_player, temp, _):


### PR DESCRIPTION
Fix #90 for Mpv.
Check initial state of the media players when they are just starting.