### PR TITLE
Manage VLC crashes for versions 3.0.13 to 3.0.16

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -85,7 +85,7 @@ for:
 
     install:
       # install system dependencies if requested
-      - "if %INTEGRATION_TEST% == true (cinst vlc --force --version=3.0.12)"
+      - "if %INTEGRATION_TEST% == true (cinst vlc)"
       - "if %INTEGRATION_TEST% == true (cinst mpv)"
 
       # the features used in setup.cfg require a recent enough version of setuptools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Security related fix.
 -->
 
+
 ## Unreleased
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installation guidelines are provided over here:
 
 At least one of there players:
 
-* [VLC](https://www.videolan.org/vlc/) (supported version: 3.0.0 and higher, note that versions 3.0.13 and 3.0.14 cannot be used);
+* [VLC](https://www.videolan.org/vlc/) (supported version: 3.0.0 and higher, note that versions 3.0.13 to 3.0.16 cannot be used);
 * [mpv](https://mpv.io/) (supported version: 0.27 and higher).
 
 For 64 bits operating systems, you must install the equivalent version of the requirements.

--- a/src/dakara_player/media_player/vlc.py
+++ b/src/dakara_player/media_player/vlc.py
@@ -7,7 +7,7 @@ import sys
 
 from dakara_base.exceptions import DakaraError
 from dakara_base.safe_workers import safe
-from packaging.version import Version, parse
+from packaging.version import parse
 
 from dakara_player.window import DummyWindowManager, WindowManager
 
@@ -190,7 +190,7 @@ class MediaPlayerVlc(MediaPlayer):
         if version.major < 3:
             raise VlcTooOldError("VLC is too old (version 3 and higher supported)")
 
-        if version in (Version("3.0.13"), Version("3.0.14")):
+        if version.minor == 0 and 13 <= version.micro <= 16:
             logger.warning(
                 "This version of VLC is known to not work with Dakara player"
             )

--- a/tests/unit/test_media_player_vlc.py
+++ b/tests/unit/test_media_player_vlc.py
@@ -265,42 +265,28 @@ class MediaPlayerVlcTestCase(BaseTestCase):
                 vlc_player.check_version()
 
     @patch.object(MediaPlayerVlc, "get_version")
-    def test_check_version_3013(self, mocked_get_version):
-        """Test to check VLC version 3.0.13."""
+    def test_check_version_problem(self, mocked_get_version):
+        """Test to check known problematic version of VLC."""
         with self.get_instance() as (vlc_player, _, _):
-            # mock the version of VLC
-            mocked_get_version.return_value = parse("3.0.13")
+            versions = ["3.0.13", "3.0.14", "3.0.15", "3.0.16"]
 
-            # call the method
-            with self.assertLogs("dakara_player.media_player.vlc", "WARNING") as logger:
-                vlc_player.check_version()
+            for version in versions:
+                # mock the version of VLC
+                mocked_get_version.return_value = parse(version)
 
-            self.assertListEqual(
-                logger.output,
-                [
-                    "WARNING:dakara_player.media_player.vlc:This version of VLC "
-                    "is known to not work with Dakara player"
-                ],
-            )
+                # call the method
+                with self.assertLogs(
+                    "dakara_player.media_player.vlc", "WARNING"
+                ) as logger:
+                    vlc_player.check_version()
 
-    @patch.object(MediaPlayerVlc, "get_version")
-    def test_check_version_3014(self, mocked_get_version):
-        """Test to check VLC version 3.0.14."""
-        with self.get_instance() as (vlc_player, _, _):
-            # mock the version of VLC
-            mocked_get_version.return_value = parse("3.0.14")
-
-            # call the method
-            with self.assertLogs("dakara_player.media_player.vlc", "WARNING") as logger:
-                vlc_player.check_version()
-
-            self.assertListEqual(
-                logger.output,
-                [
-                    "WARNING:dakara_player.media_player.vlc:This version of VLC "
-                    "is known to not work with Dakara player"
-                ],
-            )
+                self.assertListEqual(
+                    logger.output,
+                    [
+                        "WARNING:dakara_player.media_player.vlc:This version of VLC "
+                        "is known to not work with Dakara player"
+                    ],
+                )
 
     @patch.object(Path, "exists")
     def test_check_kara_folder_path(self, mocked_exists):


### PR DESCRIPTION
Blacklist the concerned versions.

~Redo tests when VLC 3.0.17 is available on [Chocolatey](https://community.chocolatey.org/packages/vlc).~ Done.