### PR TITLE
Support mpv version 0.34.0 and above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 - Fonts are automatically installed on Windows.
 - Songs can be restarted, rewound, or fast forwarded during playback.
   Duration of the rewind/fast forward jump is 10 seconds by default and can be customized in the config file using the `player.durations.rewind_fast_forward_duration` key.
+- Support of mpv 0.34.0 and above.
+- The user can force the version of mpv to use in config using the `player.mpv.force_version` key.
 
 ### Changed
 

--- a/src/dakara_player/media_player/mpv.py
+++ b/src/dakara_player/media_player/mpv.py
@@ -105,18 +105,19 @@ class MediaPlayerMpv(MediaPlayer, ABC):
         raise VersionNotFoundError("Unable to get mpv version")
 
     @staticmethod
-    def get_class_from_version():
+    def get_class_from_version(version):
         """Get the mpv media player class according to installed version.
 
+        Args:
+            version (packaging.version.Version): Arbitrary mpv version to use.
+
         Returns:
-            MediaPlayerMpv: Will return the class adapted to the current version of mpv:
+            MediaPlayerMpv: Will return the class adapted to the version of mpv:
 
                 - `MediaPlayerMpvPost0340` if mpv newer than 0.34.0;
                 - `MediaPlayerMpvPost0330` if mpv newer than 0.33.0;
                 - `MediaPlayerMpvOld` as default.
         """
-        version = MediaPlayerMpv.get_version()
-
         if version >= Version("0.34.0"):
             logger.debug("Using post 0.34.0 API of mpv")
             return MediaPlayerMpvPost0340
@@ -136,7 +137,14 @@ class MediaPlayerMpv(MediaPlayer, ABC):
             MediaPlayer: Instance of the mpv media player for the correct
             version of mpv.
         """
-        return MediaPlayerMpv.get_class_from_version()(*args, **kwargs)
+        try:
+            config = kwargs.get("config") or args[2]
+            version = Version(config["mpv"]["force_version"])
+
+        except (KeyError, IndexError):
+            version = MediaPlayerMpv.get_version()
+
+        return MediaPlayerMpv.get_class_from_version(version)(*args, **kwargs)
 
 
 class MediaPlayerMpvOld(MediaPlayerMpv):

--- a/src/dakara_player/player.py
+++ b/src/dakara_player/player.py
@@ -134,7 +134,10 @@ class DakaraWorker(WorkerSafeThread):
             # media player
             media_player = stack.enter_context(
                 self.get_media_player_class()(
-                    self.stop, self.errors, self.config["player"], tempdir
+                    self.stop,
+                    self.errors,
+                    self.config["player"],
+                    tempdir,
                 )
             )
             media_player.load()

--- a/src/dakara_player/resources/player.yaml
+++ b/src/dakara_player/resources/player.yaml
@@ -70,6 +70,14 @@ player:
   #
   # mpv --list-options
   mpv:
+    # Force a certain version of mpv.
+    # The project uses mpv differently depending on its version, which is
+    # automatically guessed. You can force the project to use mpv according to
+    # a certain version. Keep in mind that using a different version than the
+    # real current one may lead to crashes. Modify this only if you know what
+    # you are doing.
+    # force_version: 0.34.0
+
     # Enable the debanding algorithm.
     # This greatly reduces the amount of visible banding, blocking and other
     # quantization artifacts, at the expense of very slightly blurring some of the

--- a/tests/unit/test_media_player_mpv.py
+++ b/tests/unit/test_media_player_mpv.py
@@ -63,25 +63,18 @@ class MediaPlayerMpvTestCase(TestCase):
             MediaPlayerMpvOld.get_version()
 
     @patch.object(MediaPlayerMpv, "get_version")
-    def test_get_old(self, mocked_get_version):
-        """Test to get media player for old version of mpv."""
-        mocked_get_version.return_value = Version("0.27.0")
+    def test_get_class_from_version(self, mocked_get_version):
+        """Test to get media player for various versions of mpv."""
+        versions = [
+            ("0.27.0", MediaPlayerMpvOld),
+            ("0.33.0", MediaPlayerMpvPost0330),
+            ("0.34.0", MediaPlayerMpvPost0340),
+        ]
 
-        self.assertIs(MediaPlayerMpv.get_class_from_version(), MediaPlayerMpvOld)
+        for version, media_player_class in versions:
+            mocked_get_version.return_value = Version(version)
 
-    @patch.object(MediaPlayerMpv, "get_version")
-    def test_get_post_0330(self, mocked_get_version):
-        """Test to get media player for version of mpv newer than 0.33.0."""
-        mocked_get_version.return_value = Version("0.33.0")
-
-        self.assertIs(MediaPlayerMpv.get_class_from_version(), MediaPlayerMpvPost0330)
-
-    @patch.object(MediaPlayerMpv, "get_version")
-    def test_get_post_0340(self, mocked_get_version):
-        """Test to get media player for version of mpv newer than 0.34.0."""
-        mocked_get_version.return_value = Version("0.34.0")
-
-        self.assertIs(MediaPlayerMpv.get_class_from_version(), MediaPlayerMpvPost0340)
+            self.assertIs(MediaPlayerMpv.get_class_from_version(), media_player_class)
 
     @patch.object(MediaPlayerMpv, "get_class_from_version")
     def test_instanciate(self, mocked_get_class_from_version):


### PR DESCRIPTION
The latest version of mpv seems to not consider pause/unpause an event anymore, the code uses property observer instead. Also, the user can now force the mpv version to use for the project.