### PR TITLE
Silent mpv socket close failures on Windows

### DIFF
--- a/src/dakara_player/media_player/mpv.py
+++ b/src/dakara_player/media_player/mpv.py
@@ -39,6 +39,20 @@ MPV_ERROR_LEVELS = {
 PLAYER_IS_AVAILABLE_ATTEMPTS = 5
 
 
+# monkey patch mpv to silent socket close failures on windows
+if mpv is not None:
+
+    class WindowsSocketSilenced(mpv.WindowsSocket):
+        def stop(self, *args, **kwargs):
+            try:
+                super().stop(*args, **kwargs)
+
+            except OSError:
+                pass
+
+    mpv.WindowsSocket = WindowsSocketSilenced
+
+
 class MediaPlayerMpv(MediaPlayer, ABC):
     """Abstract class to manipulate mpv.
 


### PR DESCRIPTION
A patch was proposed and integrated in `python_mpv_jsonipc`, but no new release was done. The library is monkey patched to obtain the same result.