### PR TITLE
Include all resources in python package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,9 @@ tests =
 [options.packages.find]
 where = src
 
+[options.package_data]
+dakara_player.resources = *
+
 [options.entry_points]
 console_scripts =
         dakara-player = dakara_player.__main__:main


### PR DESCRIPTION
Explicitly declare files in dakara_player.resources as package data.

This forces the inclusion of the `line-awesome.json` file in the resulting package which seems to be missing from the 1.8.0 package (causing an error when launching the error).