### PR TITLE
Drop Python 3.7 support and add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +58,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install native dependencies (Ubuntu)
@@ -110,7 +111,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           # MacOS disabled for now
           - windows-latest
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added Python 3.12 support.
+
 ### Removed
 
 - Dropped Python 3.7 support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 
 ## Unreleased
 
+### Removed
+
+- Dropped Python 3.7 support.
+
 ## 1.8.1 - 2022-12-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: OS Independent",
         "Environment :: X11 Applications",
         "Environment :: Win32 (MS Windows)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,11 @@ description = "Media player for the Dakara Project"
 readme = "README.md"
 license = {file = "LICENSE"}
 dynamic = ["version"]
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 classifiers = [
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -27,7 +26,6 @@ dependencies = [
         "Jinja2>=3.1.1,<3.2.0",
         "dakarabase>=1.4.2,<1.5.0",
         "filetype>=1.2.0,<1.3.0",
-        "importlib-resources>=5.10.0,<5.11.0; python_version < '3.7'",
         "packaging>=21.3,<22.0",
         "path>=16.4.0,<16.5.0",
         "python-mpv-jsonipc>=1.1.13,<1.2.0",

--- a/src/dakara_player/background.py
+++ b/src/dakara_player/background.py
@@ -1,12 +1,7 @@
 """Manage background images for media players."""
 
 import logging
-
-try:
-    from importlib.resources import path
-
-except ImportError:
-    from importlib_resources import path
+from importlib.resources import path
 
 from dakara_base.exceptions import DakaraError
 from path import Path

--- a/src/dakara_player/font.py
+++ b/src/dakara_player/font.py
@@ -4,16 +4,10 @@ import ctypes
 import logging
 import platform
 from abc import ABC, abstractmethod
-
-from path import Path
-
-try:
-    from importlib.resources import contents, path
-
-except ImportError:
-    from importlib_resources import contents, path
+from importlib.resources import contents, path
 
 from dakara_base.exceptions import DakaraError
+from path import Path
 
 logger = logging.getLogger(__name__)
 

--- a/src/dakara_player/text.py
+++ b/src/dakara_player/text.py
@@ -2,17 +2,11 @@
 
 import json
 import logging
+from importlib.resources import path
 
 from dakara_base.exceptions import DakaraError
 from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader
 from path import Path
-
-try:
-    from importlib.resources import path
-
-except ImportError:
-    from importlib_resources import path
-
 
 ICON_MAP_FILE = "line-awesome.json"
 

--- a/src/dakara_player/user_resources.py
+++ b/src/dakara_player/user_resources.py
@@ -2,12 +2,7 @@
 
 import logging
 from distutils.util import strtobool
-
-try:
-    from importlib.resources import contents, path
-
-except ImportError:
-    from importlib_resources import path, contents
+from importlib.resources import contents, path
 
 from dakara_base.directory import directories
 from path import Path


### PR DESCRIPTION
This MR aims to drop the latest unsupported Python version (3.7) and support the latest version (3.12).

This MR may need the latest `dakara-base` version, to support the in-house implementation of `strtobool`.