### PR TITLE
setup ruff as a flake8 replacement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,3 +122,6 @@ jobs:
 
       - name: Run style checks
         run: python -m black . --check
+
+      - name: Run ruff linter
+        run: python -m ruff check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,8 @@ repos:
         entry: black . --check
         language: system
         pass_filenames: false
-      - id: flake8-check
-        name: Check PEP8
-        entry: flake8
+      - id: ruff-check
+        name: Run ruff linter
+        entry: ruff check .
         language: system
         pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
         "pre-commit>=2.20.0,<2.21.0",
         "pytest-cov>=4.0.0,<4.1.0",
         "pytest>=7.2.0,<7.3.0",
+        "ruff",
 ]
 
 [project.urls]
@@ -71,3 +72,8 @@ addopts = "--cov=dakara_player"
 
 [tool.isort]
 profile = "black"
+
+[tool.ruff]
+select = ["E", "F", "W", "B"]
+line-length = 88
+ignore = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
         "pre-commit>=2.20.0,<2.21.0",
         "pytest-cov>=4.0.0,<4.1.0",
         "pytest>=7.2.0,<7.3.0",
-        "ruff",
+        "ruff>=0.3.0,<0.4.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ addopts = "--cov=dakara_player"
 profile = "black"
 
 [tool.ruff]
-select = ["E", "F", "W", "B"]
 line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "B"]
 ignore = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-ignore = E203, W503

--- a/tests/unit/test_media_player_mpv.py
+++ b/tests/unit/test_media_player_mpv.py
@@ -698,7 +698,7 @@ class MediaPlayerMpvOldTestCase(MediaPlayerMpvModelTestCase):
         mpv_player, (mocked_player, _, _), _ = self.get_instance(
             {"mpv": {"key1": "value1"}}
         )
-        self.assertEqual(getattr(mocked_player, "key1"), "value1")
+        self.assertEqual(mocked_player.key1, "value1")
 
     def test_play_invalid(self):
         """Test to play invalid action."""


### PR DESCRIPTION
ruff runs pretty fast, which is nice when used as a pre-commit hook.

It also implements more checks that can be selected as needed, in this
PR I add the bugbear (B) checks which were not present in the
previous configuration and fix the issue it reports.