### PR TITLE
vlc: catch errors when instanciating vlc in is_available

### DIFF
--- a/src/dakara_player/media_player/vlc.py
+++ b/src/dakara_player/media_player/vlc.py
@@ -90,7 +90,11 @@ class MediaPlayerVlc(MediaPlayer):
         Returns:
             bool: `True` if VLC is useable.
         """
-        return vlc is not None and vlc.Instance() is not None
+        try:
+            return vlc is not None and vlc.Instance() is not None
+        except NameError:
+            logger.exception("Failed to start VLC.")
+            return False
 
     def init_player(self, config, tempdir):
         """Initialize the objects of VLC.

--- a/tests/unit/test_media_player_vlc.py
+++ b/tests/unit/test_media_player_vlc.py
@@ -210,6 +210,12 @@ class MediaPlayerVlcTestCase(BaseTestCase):
                 vlc.EventType.MediaPlayerEndReached, callback
             )
 
+    @skipIf(vlc is None, "VLC not installed")
+    def test_vlc_unavailable(self):
+        """Test that is_available returns False when vlc.Instance raises a NameError."""
+        with patch.object(vlc, "Instance", side_effect=NameError()):
+            self.assertFalse(MediaPlayerVlc.is_available())
+
     @patch("dakara_player.media_player.vlc.libvlc_get_version")
     def test_get_version_long_4_digits(self, mocked_libvlc_get_version):
         """Test to get the VLC version when it is long and contains 4 digits."""


### PR DESCRIPTION
This would make the tests fail on a system without VLC installed. Detecting it in is_available skips the tests.

For reference this is the error I get:
```
Traceback (most recent call last):
  File "/home/odrling/git/misc/dakara-player/src/dakara_player/media_player/vlc.py", line 94, in is_available
    return vlc is not None and vlc.Instance() is not None
                               ^^^^^^^^^^^^^^
  File "/home/odrling/git/misc/dakara-player/.direnv/python-3.12/lib/python3.12/site-packages/vlc.py", line 1838, in __new__
    return libvlc_new(len(args), args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odrling/git/misc/dakara-player/.direnv/python-3.12/lib/python3.12/site-packages/vlc.py", line 5014, in libvlc_new
    _Cfunction('libvlc_new', ((1,), (1,),), class_result(Instance),
  File "/home/odrling/git/misc/dakara-player/.direnv/python-3.12/lib/python3.12/site-packages/vlc.py", line 302, in _Cfunction
    raise NameError('no function %r' % (name,))
NameError: no function 'libvlc_new'
```