### PR TITLE
ci: remove lock on windows' mpv version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install native dependencies (Windows)
         run: |
           choco install --no-progress vlc
-          choco install mpvio.install --no-progress --version=0.36.0 # FIXME release this lock when possible
+          choco install mpvio.install --no-progress
           # update the PATH variable (because shims are not possible for vlc/mpv)
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv


### PR DESCRIPTION
mpv 0.38.0 is available in the Chocolatey repository and should work fine for our needs.

Tests won't pass without #123