### PR TITLE
ci: use ubuntu 24.04 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04 # FIXME release this lock when possible
+          - ubuntu-24.04 # FIXME release this lock when possible
           # MacOS disabled for now
           - windows-latest
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install native dependencies (Ubuntu)
         run: sudo apt-get update && sudo apt-get install -y vlc mpv
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-24.04'
 
       - name: Install native dependencies (MacOS)
         run: brew install vlc mpv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install native dependencies (Ubuntu)
         run: sudo apt-get update && sudo apt-get install -y vlc mpv
-        if: matrix.os == 'ubuntu-latest
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Install native dependencies (MacOS)
         run: brew install vlc mpv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-24.04 # FIXME release this lock when possible
+          - ubuntu-latest
           # MacOS disabled for now
           - windows-latest
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install native dependencies (Ubuntu)
         run: sudo apt-get update && sudo apt-get install -y vlc mpv
-        if: matrix.os == 'ubuntu-24.04'
+        if: matrix.os == 'ubuntu-latest
 
       - name: Install native dependencies (MacOS)
         run: brew install vlc mpv


### PR DESCRIPTION
~~The ubuntu-24.04 image is in beta (so it is not ubuntu-latest yet)~~ Ubuntu 24.04 is now available through `ubuntu-latest`:

- https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available/
- https://github.com/actions/runner-images/issues/10636