### PR TITLE
Fix wrong Python version in Windows integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: "pip"
-
       - name: Install native dependencies (Ubuntu)
         run: sudo apt-get update && sudo apt-get install -y vlc mpv
         if: matrix.os == 'ubuntu-latest'
@@ -91,6 +86,11 @@ jobs:
 
       - name: Print Mpv version
         run: mpv --version
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
 
       - name: Install python tests dependencies
         run: pip install -e ".[dev]"


### PR DESCRIPTION
During integration tests on Windows, Python is reported to be 3.9, when it should be 3.12. This PR aims to solve this incoherence.