### PR TITLE
Fix `"None"` passed as audio file by default

### DIFF
--- a/src/dakara_player/media_player/mpv.py
+++ b/src/dakara_player/media_player/mpv.py
@@ -404,7 +404,7 @@ class MediaPlayerMpvOld(MediaPlayerMpv):
                     logger.debug("Requesting to play audio track 2")
 
                 else:
-                    self.player.audio_files = [self(path_audio)]
+                    self.player.audio_files = [str(path_audio)]
                     logger.debug("Requesting to play audio file %s", path_audio)
 
             # if the subtitle file cannot be discovered, do not request it

--- a/src/dakara_player/media_player/mpv.py
+++ b/src/dakara_player/media_player/mpv.py
@@ -395,7 +395,7 @@ class MediaPlayerMpvOld(MediaPlayerMpv):
 
         if what == "song":
             # manage instrumental track/file
-            path_audio = str(self.playlist_entry_data["song"].path_audio)
+            path_audio = self.playlist_entry_data["song"].path_audio
             if path_audio:
                 if path_audio == "self":
                     # mpv use different index for each track, so we can safely request
@@ -404,7 +404,7 @@ class MediaPlayerMpvOld(MediaPlayerMpv):
                     logger.debug("Requesting to play audio track 2")
 
                 else:
-                    self.player.audio_files = [path_audio]
+                    self.player.audio_files = [self(path_audio)]
                     logger.debug("Requesting to play audio file %s", path_audio)
 
             # if the subtitle file cannot be discovered, do not request it

--- a/tests/integration/test_media_player_mpv.py
+++ b/tests/integration/test_media_player_mpv.py
@@ -202,6 +202,9 @@ class MediaPlayerMpvIntegrationTestCase(TestCasePollerKara):
             # check audio track
             self.assertEqual(mpv_player.player.audio, 1)
 
+            # check there is no audio file
+            self.assertEqual(len(mpv_player.player.audio_files), 0)
+
             # assert the started song callback has been called
             mpv_player.callbacks["started_song"].assert_called_with(
                 self.playlist_entry1["id"]
@@ -251,6 +254,9 @@ class MediaPlayerMpvIntegrationTestCase(TestCasePollerKara):
             # check audio track
             self.assertEqual(mpv_player.player.audio, 2)
 
+            # check there is no audio file
+            self.assertEqual(len(mpv_player.player.audio_files), 0)
+
             # assert the started song callback has been called
             mpv_player.callbacks["started_song"].assert_called_with(
                 self.playlist_entry1["id"]
@@ -284,6 +290,10 @@ class MediaPlayerMpvIntegrationTestCase(TestCasePollerKara):
 
             # check audio track
             self.assertEqual(mpv_player.player.audio, 3)
+
+            # check audio file
+            self.assertEqual(len(mpv_player.player.audio_files), 1)
+            self.assertEqual(mpv_player.player.audio_files[0], str(self.audio2_path))
 
             # assert the started song callback has been called
             mpv_player.callbacks["started_song"].assert_called_with(


### PR DESCRIPTION
Fixes #138.

But I don't like that a variable may contain `None`, `"self"` and a `pathlibi.Path` instance at the same time.